### PR TITLE
Implement Stringer interface for Item type

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,10 @@ type Item struct {
 	URL   string
 }
 
+func (i Item) String() string {
+	return fmt.Sprintf("Title: %s\nURL: %s", i.Title, i.URL)
+}
+
 type Response struct {
 	Data struct {
 		Children []struct {


### PR DESCRIPTION
Improve the readability of the output by implementing the Stringer
interface for the Item type.  The difference between the title
and URL of an item is now clear.
